### PR TITLE
French interpretation of quatre vingt didn't take enough context.

### DIFF
--- a/src/lang/fr/mod.rs
+++ b/src/lang/fr/mod.rs
@@ -65,8 +65,8 @@ impl LangInterpretor for French {
                 b"80" => b.fput(b"96"),
                 _ => b.put(b"16"),
             },
-            "vingt" | "vingtième" => match b.peek(1) {
-                b"4" => b.fput(b"80"),
+            "vingt" | "vingtième" => match b.peek(2) {
+                b"04" | b"4" => b.fput(b"80"),
                 _ => b.put(b"20"),
             },
             "trente" | "trentième" => b.put(b"30"),
@@ -131,7 +131,7 @@ impl LangInterpretor for French {
 
 #[cfg(test)]
 mod tests {
-    use super::French;
+    use super::*;
     use crate::word_to_digit::{replace_numbers, text2digits};
 
     macro_rules! assert_text2digits {
@@ -164,6 +164,15 @@ mod tests {
             let res = text2digits($text, &f);
             assert!(res.is_err());
         };
+    }
+
+    #[test]
+    fn test_apply_steps() {
+        let f = French {};
+        let mut b = DigitString::new();
+        assert!(f.apply("trente", &mut b).is_ok());
+        assert!(f.apply("quatre", &mut b).is_ok());
+        assert!(f.apply("vingt", &mut b).is_err());
     }
 
     #[test]
@@ -238,6 +247,7 @@ mod tests {
         assert_invalid!("dix deux");
         assert_invalid!("dix unième");
         assert_invalid!("vingtième cinq");
+        assert_invalid!("zéro zéro trente quatre vingt");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,15 @@ mod tests {
     }
 
     #[test]
+    fn test_zeros_fr() {
+        let french = Language::french();
+        assert_eq!(
+            replace_numbers("zéro zéro trente quatre vingt", &french, 10.),
+            "0034 20"
+        );
+    }
+
+    #[test]
     fn test_access_en() {
         let english = Language::english();
         assert_eq!(

--- a/src/word_to_digit.rs
+++ b/src/word_to_digit.rs
@@ -151,7 +151,7 @@ impl NumTracker {
 }
 
 /// Find spelled numbers (including decimal) in the `text` and replace them by their digit representation.
-/// Isolated digists strictly under `threshold` are not converted (set to 0.0 to convert everything).
+/// Isolated digits strictly under `threshold` are not converted (set to 0.0 to convert everything).
 pub fn replace_numbers<T: LangInterpretor>(text: &str, lang: &T, threshold: f64) -> String {
     let mut parser = WordToDigitParser::new(lang);
     let mut out: Vec<String> = Vec::with_capacity(40);


### PR DESCRIPTION
https://app.clubhouse.io/allomedia/story/19210/bug-zéro-zéro-trentre-quatre-vingt-dix-sept-is-not-0097