### PR TITLE
v2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text2num"
-version = "1.7.0"
+version = "2.0.0"
 authors = ["Allo-Media <contact@allo-media.fr>"]
 edition = "2021"
 license = "MIT"

--- a/src/digit_string.rs
+++ b/src/digit_string.rs
@@ -30,6 +30,14 @@ impl DigitString {
         }
     }
 
+    /// Clear DigitString as if it was brand new.
+    pub fn reset(&mut self) {
+        self.leading_zeroes = 0;
+        self.frozen = false;
+        self.marker = MorphologicalMarker::None;
+        self.buffer.clear();
+    }
+
     /// Freeze the DigitSring to signal the number is complete.
     ///
     /// Useful for languages that use some kind of flexion or suffix to mark the end.

--- a/src/lang/en/mod.rs
+++ b/src/lang/en/mod.rs
@@ -124,7 +124,7 @@ impl LangInterpretor for English {
         word == "point"
     }
 
-    fn format_and_value(&self, b: DigitString) -> (String, f64) {
+    fn format_and_value(&self, b: &DigitString) -> (String, f64) {
         let repr = b.to_string();
         let val: f64 = repr.parse().unwrap();
         if let MorphologicalMarker::Ordinal(marker) = b.marker {
@@ -134,7 +134,7 @@ impl LangInterpretor for English {
         }
     }
 
-    fn format_decimal_and_value(&self, int: DigitString, dec: DigitString) -> (String, f64) {
+    fn format_decimal_and_value(&self, int: &DigitString, dec: &DigitString) -> (String, f64) {
         let irepr = int.to_string();
         let drepr = dec.to_string();
         let frepr = format!("{}.{}", irepr, drepr);

--- a/src/lang/es/mod.rs
+++ b/src/lang/es/mod.rs
@@ -126,7 +126,7 @@ impl LangInterpretor for Spanish {
         word == "coma"
     }
 
-    fn format_and_value(&self, b: DigitString) -> (String, f64) {
+    fn format_and_value(&self, b: &DigitString) -> (String, f64) {
         let repr = b.to_string();
         let val: f64 = repr.parse().unwrap();
         match b.marker {
@@ -136,7 +136,7 @@ impl LangInterpretor for Spanish {
         }
     }
 
-    fn format_decimal_and_value(&self, int: DigitString, dec: DigitString) -> (String, f64) {
+    fn format_decimal_and_value(&self, int: &DigitString, dec: &DigitString) -> (String, f64) {
         let sint = int.to_string();
         let sdec = dec.to_string();
         let val = format!("{}.{}", sint, sdec).parse().unwrap();

--- a/src/lang/es/mod.rs
+++ b/src/lang/es/mod.rs
@@ -40,7 +40,7 @@ impl LangInterpretor for Spanish {
         }
         let status = match lemmatize(num_func) {
             "cero" => b.put(b"0"),
-            "un" | "uno" if b.peek(2) != b"10" && b.peek(2) != b"20" => b.put(b"1"),
+            "un" | "uno" | "una" if b.peek(2) != b"10" && b.peek(2) != b"20" => b.put(b"1"),
             "primer" | "primero" | "primera" => b.put(b"1"),
             "dos" if b.peek(2) != b"10" && b.peek(2) != b"20" => b.put(b"2"),
             "segundo" if b.marker.is_ordinal() => b.put(b"2"),
@@ -76,7 +76,7 @@ impl LangInterpretor for Spanish {
             "dieciocho" | "decimoctavo" | "decimoctava" | "dieciochoavo" => b.put(b"18"),
             "diecinueve" | "decimonoveno" | "decimonovena" | "decinueveavo" => b.put(b"19"),
             "veinte" | "vigésimo" | "vigésima" | "veintavo" | "veinteavo" => b.put(b"20"),
-            "veintiuno" | "veintiunoavo" => b.put(b"21"),
+            "veintiuno" | "veintiuna" | "veintiunoavo" => b.put(b"21"),
             "veintidós" | "veintidos" | "veintidosavo" => b.put(b"22"),
             "veintitrés" | "veintitres" | "veintitresavo" => b.put(b"23"),
             "veinticuatro" | "veinticuatroavo" => b.put(b"24"),
@@ -92,15 +92,17 @@ impl LangInterpretor for Spanish {
             "setenta" | "septuagésimo" | "septuagésima" | "setentavo" => b.put(b"70"),
             "ochenta" | "octogésimo" | "octogésima" | "ochentavo" => b.put(b"80"),
             "noventa" | "nonagésimo" | "nonagésima" | "noventavo" => b.put(b"90"),
-            "cien" | "ciento" | "centésimo" | "centésima" | "centavo" => b.put(b"100"),
-            "dosciento" | "ducentésimo" | "ducentésima" => b.put(b"200"),
-            "tresciento" | "tricentésimo" | "tricentésima" => b.put(b"300"),
-            "cuatrociento" | "quadringentésimo" | "quadringentésima" => b.put(b"400"),
-            "quiniento" | "quingentésimo" | "quingentésima" => b.put(b"500"),
-            "seisciento" | "sexcentésimo" | "sexcentésima" => b.put(b"600"),
-            "seteciento" | "septingentésimo" | "septingentésima" => b.put(b"700"),
-            "ochociento" | "octingentésimo" | "octingentésima" => b.put(b"800"),
-            "noveciento" | "noningentésimo" | "noningentésima" => b.put(b"900"),
+            "cien" | "ciento" | "cienta" | "centésimo" | "centésima" | "centavo" => b.put(b"100"),
+            "dosciento" | "doscienta" | "ducentésimo" | "ducentésima" => b.put(b"200"),
+            "tresciento" | "trescienta" | "tricentésimo" | "tricentésima" => b.put(b"300"),
+            "cuatrociento" | "cuatrocienta" | "quadringentésimo" | "quadringentésima" => {
+                b.put(b"400")
+            }
+            "quiniento" | "quinienta" | "quingentésimo" | "quingentésima" => b.put(b"500"),
+            "seisciento" | "seiscienta" | "sexcentésimo" | "sexcentésima" => b.put(b"600"),
+            "seteciento" | "setecienta" | "septingentésimo" | "septingentésima" => b.put(b"700"),
+            "ochociento" | "ochocienta" | "octingentésimo" | "octingentésima" => b.put(b"800"),
+            "noveciento" | "novecienta" | "noningentésimo" | "noningentésima" => b.put(b"900"),
             "mil" | "milésimo" | "milésima" => b.shift(3),
             "millon" | "millón" | "millonésimo" | "millonésima" => b.shift(6),
             "y" if b.len() >= 2 => Err(Error::Incomplete),
@@ -236,6 +238,7 @@ mod tests {
         assert_text2digits!("ochenta y uno", "81");
         assert_text2digits!("cien", "100");
         assert_text2digits!("ciento uno", "101");
+        assert_text2digits!("cienta una", "101");
         assert_text2digits!("ciento quince", "115");
         assert_text2digits!("doscientos", "200");
         assert_text2digits!("doscientos uno", "201");
@@ -320,6 +323,10 @@ mod tests {
         assert_replace_numbers!(
             "Veinticinco vacas, doce gallinas y ciento veinticinco kg de patatas.",
             "25 vacas, 12 gallinas y 125 kg de patatas."
+        );
+        assert_replace_numbers!(
+            "trescientos hombres y quinientas mujeres",
+            "300 hombres y 500 mujeres"
         );
         assert_replace_numbers!("Mil doscientos sesenta y seis dolares.", "1266 dolares.");
         assert_replace_numbers!("un dos tres cuatro veinte quince.", "1 2 3 4 20 15.");

--- a/src/lang/fr/mod.rs
+++ b/src/lang/fr/mod.rs
@@ -353,6 +353,10 @@ mod tests {
             "12,99, 120,05, 1,236, 1,2 3 6."
         );
         assert_replace_numbers!("zéro virgule cent douze", "0,112");
+        assert_replace_numbers!(
+            "la densité moyenne est de zéro virgule cinq.",
+            "la densité moyenne est de 0,5."
+        );
     }
 
     #[test]

--- a/src/lang/fr/mod.rs
+++ b/src/lang/fr/mod.rs
@@ -137,7 +137,7 @@ impl LangInterpretor for French {
         word == "virgule"
     }
 
-    fn format_and_value(&self, b: DigitString) -> (String, f64) {
+    fn format_and_value(&self, b: &DigitString) -> (String, f64) {
         let repr = b.to_string();
         let val = repr.parse().unwrap();
         if let MorphologicalMarker::Ordinal(marker) = b.marker {
@@ -147,7 +147,7 @@ impl LangInterpretor for French {
         }
     }
 
-    fn format_decimal_and_value(&self, int: DigitString, dec: DigitString) -> (String, f64) {
+    fn format_decimal_and_value(&self, int: &DigitString, dec: &DigitString) -> (String, f64) {
         let sint = int.to_string();
         let sdec = dec.to_string();
         let val = format!("{}.{}", sint, sdec).parse().unwrap();

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -83,11 +83,11 @@ pub trait LangInterpretor {
     /// For example `"point"` is a decimal separator in English.
     fn is_decimal_sep(&self, word: &str) -> bool;
     /// Format `b` as digit string and evaluate it, according to the language's rules.
-    fn format_and_value(&self, b: DigitString) -> (String, f64);
+    fn format_and_value(&self, b: &DigitString) -> (String, f64);
     /// Format the decimal number given as integral part `int` and decimals `dec` according the the language's rules.
     ///
     /// Also return its value as float.
-    fn format_decimal_and_value(&self, int: DigitString, dec: DigitString) -> (String, f64);
+    fn format_decimal_and_value(&self, int: &DigitString, dec: &DigitString) -> (String, f64);
     /// Return true if `word` does not isolate numbers in a sequence, but links them, or is truely insignificant noise.
     ///
     /// For example, in English in the phrase "*two plus three is uh five*", the words "*plus*" and "*is*" are linking words,
@@ -167,7 +167,7 @@ macro_rules! delegate {
                 )*
             }
         }
-        fn format_and_value(&self, b: DigitString) -> (String, f64){
+        fn format_and_value(&self, b: &DigitString) -> (String, f64){
             match self{
                 $(
                     Language::$variant(l) => l.format_and_value(b),
@@ -175,7 +175,7 @@ macro_rules! delegate {
             }
         }
 
-        fn format_decimal_and_value(&self, int: DigitString, dec: DigitString) -> (String, f64) {
+        fn format_decimal_and_value(&self, int: &DigitString, dec: &DigitString) -> (String, f64) {
             match self {
                 $(
                     Language::$variant(l) => l.format_decimal_and_value(int, dec),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ use text2num::{rewrite_numbers, Language};
 let en = Language::english();
 
 // Poor man's tokenizer
-let stream = "I have two hundreds and twenty dollars in my pocket".split_whitespace().map(|s| s.to_owned());
+let stream = "I have two hundreds and twenty dollars in my pocket".split_whitespace().map(|s| s.to_owned()).collect();
 
 let processed_stream = rewrite_numbers(stream, &en, 10.0);
 
@@ -143,15 +143,12 @@ impl Token for DecodedWord<'_> {
         self.text.to_lowercase()
     }
 
-    fn update<I: Iterator<Item = Self>>(&mut self, _iterator: I) {
-        // not needed here
-    }
-
     fn nt_separated(&self, previous: &Self) -> bool {
         // if there is a voice pause of more than 100ms between words, it is worth a punctuation
         self.start - previous.end > 100
     }
 }
+
 
 // Simulate ASR output
 
@@ -164,7 +161,7 @@ let stream = [
     DecodedWord{ text: "in", start: 800, end: 900},
     DecodedWord{ text: "my", start: 900, end: 1000},
     DecodedWord{ text: "pocket", start: 1010, end: 1410},
-].iter();
+].into_iter();
 
 // Process
 

--- a/src/word_to_digit.rs
+++ b/src/word_to_digit.rs
@@ -307,7 +307,7 @@ where
         }
         let lo_token = token.text_lowercase();
         let test = if let Some(ref prev) = self.previous {
-            if token.nt_separated(prev) {
+            if self.parser.has_number() && token.nt_separated(prev) {
                 "," // force stop without loosing token (see below)
             } else {
                 &lo_token
@@ -498,6 +498,23 @@ mod tests {
         assert_eq!(ocs.len(), 1);
         assert_eq!(ocs[0].text, "37");
         assert_eq!(ocs[0].value, 37.0);
+    }
+
+    #[test]
+    fn test_find_isolated_with_leading_zero() {
+        let fr = Language::french();
+        let ocs = find_numbers(
+            "quatre-vingt-douze slash zéro deux"
+                .split_whitespace()
+                .map(|s| s.to_owned())
+                .collect::<Vec<String>>()
+                .iter(),
+            &fr,
+            10.0,
+        );
+        dbg!(&ocs);
+        assert_eq!(ocs.len(), 2);
+        assert_eq!(ocs[1].text, "02");
     }
 
     #[test]


### PR DESCRIPTION
New:
  * Iterator API
  * Backward incompatible API changes for consistency
  * [Spanish] support for feminine cardinals
Fixes:
  * Fixed case where numbers where missed when using `nt_separated`