### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,29 @@ repository = "https://github.com/allo-media/text2num-rs"
 readme = "README.md"
 exclude = [".circleci", ".gitignore"]
 
+[features]
+default = ["all_languages", "std"]
+std = ["phf/std"]
+
+# Languages
+de = []
+en = []
+es = []
+fr = []
+it = []
+nl = []
+pt = []
+all_languages = [
+    "de",
+    "en",
+    "es",
+    "fr",
+    "it",
+    "nl",
+    "pt",
+]
 
 [dependencies]
-phf = { version = "0.8", features = ["macros"] }
+phf = { version = "0.8", default-features = false, features = ["macros"] }
 bitflags = "1.3"
 daachorse = "1"

--- a/src/digit_string.rs
+++ b/src/digit_string.rs
@@ -481,4 +481,20 @@ mod tests {
         assert!(!dstring.is_position_free(3));
         assert!(!dstring.is_position_free(5));
     }
+
+    #[test]
+    fn test_int_parse() {
+        let mut dstring = DigitString::new();
+        dstring.buffer = Vec::from(b"12345000");
+        dstring.leading_zeroes = 1000;
+        assert_eq!(dstring.parse(), 12345000)
+    }
+
+    #[test]
+    fn test_decimal_parse() {
+        let mut dstring = DigitString::new();
+        dstring.buffer = Vec::from(b"123");
+        dstring.leading_zeroes = 3;
+        assert_eq!(dstring.parse_decimal(), 0.000123)
+    }
 }

--- a/src/digit_string.rs
+++ b/src/digit_string.rs
@@ -264,7 +264,9 @@ impl Default for DigitString {
 /// Formal base 10 string representation with leading zeroes
 impl core::fmt::Display for DigitString {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        for _ in 0..self.leading_zeroes { f.write_char('0')?; }
+        for _ in 0..self.leading_zeroes {
+            f.write_char('0')?;
+        }
         f.write_str(core::str::from_utf8(self.buffer.as_slice()).unwrap())
     }
 }

--- a/src/lang/de/mod.rs
+++ b/src/lang/de/mod.rs
@@ -219,30 +219,7 @@ impl LangInterpreter for German {
             _ => None,
         }
     }
-
-    fn format_and_value(&self, b: &DigitString) -> (String, f64) {
-        let repr = b.to_string();
-        let val: f64 = repr.parse().unwrap();
-        if let MorphologicalMarker::Ordinal(marker) = b.marker {
-            (format!("{}{}", b.to_string(), marker), val)
-        } else {
-            (repr, val)
-        }
-    }
-
-    fn format_decimal_and_value(
-        &self,
-        int: &DigitString,
-        dec: &DigitString,
-        sep: char,
-    ) -> (String, f64) {
-        let irepr = int.to_string();
-        let drepr = dec.to_string();
-        let frepr = format!("{irepr}{sep}{drepr}");
-        let val = format!("{irepr}.{drepr}").parse().unwrap();
-        (frepr, val)
-    }
-
+    
     fn get_morph_marker(&self, word: &str) -> MorphologicalMarker {
         if word.ends_with("te") {
             MorphologicalMarker::Ordinal(".")
@@ -265,7 +242,7 @@ mod tests {
         ($text:expr, $res:expr) => {
             let f = German::new();
             let res = text2digits($text, &f);
-            dbg!(&res);
+            crate::tests::dbg!(&res);
             assert!(res.is_ok());
             assert_eq!(res.unwrap(), $res)
         };

--- a/src/lang/en/mod.rs
+++ b/src/lang/en/mod.rs
@@ -1,5 +1,7 @@
 //! English number interpreter
 
+use alloc::{format, string::String, vec::Vec};
+
 use crate::digit_string::DigitString;
 use crate::error::Error;
 
@@ -124,27 +126,14 @@ impl LangInterpreter for English {
         if word == "point" { Some('.') } else { None }
     }
 
-    fn format_and_value(&self, b: &DigitString) -> (String, f64) {
-        let repr = b.to_string();
-        let val: f64 = repr.parse().unwrap();
-        if let MorphologicalMarker::Ordinal(marker) = b.marker {
-            (format!("{}{}", b.to_string(), marker), val)
-        } else {
-            (repr, val)
-        }
-    }
-
     fn format_decimal_and_value(
         &self,
         int: &DigitString,
         dec: &DigitString,
         _sep: char,
     ) -> (String, f64) {
-        let irepr = int.to_string();
-        let drepr = dec.to_string();
-        let frepr = format!("{irepr}.{drepr}");
-        let val = frepr.parse().unwrap();
-        (frepr, val)
+        let val = int.parse() as f64 + dec.parse_decimal();
+        (format!("{int}.{dec}"), val)
     }
 
     fn get_morph_marker(&self, word: &str) -> MorphologicalMarker {
@@ -215,7 +204,7 @@ mod tests {
         ($text:expr, $res:expr) => {
             let f = English {};
             let res = text2digits($text, &f);
-            dbg!(&res);
+            crate::tests::dbg!(&res);
             assert!(res.is_ok());
             assert_eq!(res.unwrap(), $res)
         };

--- a/src/lang/es/mod.rs
+++ b/src/lang/es/mod.rs
@@ -1,4 +1,7 @@
 //! Spanish number interpreter
+
+use alloc::{format, string::String};
+
 use crate::digit_string::DigitString;
 use crate::error::Error;
 
@@ -135,25 +138,12 @@ impl LangInterpreter for Spanish {
     }
 
     fn format_and_value(&self, b: &DigitString) -> (String, f64) {
-        let repr = b.to_string();
-        let val: f64 = repr.parse().unwrap();
+        let val: f64 = b.parse() as f64;
         match b.marker {
-            MorphologicalMarker::Fraction(_) => (format!("1/{repr}"), val.recip()),
-            MorphologicalMarker::Ordinal(marker) => (format!("{repr}{marker}"), val),
-            MorphologicalMarker::None => (repr, val),
+            MorphologicalMarker::Fraction(_) => (format!("1/{b}"), val.recip()),
+            MorphologicalMarker::Ordinal(marker) => (format!("{b}{marker}"), val),
+            MorphologicalMarker::None => (alloc::string::ToString::to_string(&b), val),
         }
-    }
-
-    fn format_decimal_and_value(
-        &self,
-        int: &DigitString,
-        dec: &DigitString,
-        sep: char,
-    ) -> (String, f64) {
-        let sint = int.to_string();
-        let sdec = dec.to_string();
-        let val = format!("{sint}.{sdec}").parse().unwrap();
-        (format!("{sint}{sep}{sdec}"), val)
     }
 
     fn get_morph_marker(&self, word: &str) -> MorphologicalMarker {
@@ -194,7 +184,7 @@ mod tests {
         ($text:expr, $res:expr) => {
             let f = Spanish {};
             let res = text2digits($text, &f);
-            dbg!(&res);
+            crate::tests::dbg!(&res);
             assert!(res.is_ok());
             assert_eq!(res.unwrap(), $res)
         };

--- a/src/lang/fr/mod.rs
+++ b/src/lang/fr/mod.rs
@@ -1,6 +1,9 @@
 //! French number interpreter.
 //!
 //! It supports regional variants.
+
+use alloc::vec::Vec;
+
 use bitflags::bitflags;
 
 use crate::digit_string::DigitString;
@@ -229,28 +232,6 @@ impl LangInterpreter for French {
         if word == "virgule" { Some(',') } else { None }
     }
 
-    fn format_and_value(&self, b: &DigitString) -> (String, f64) {
-        let repr = b.to_string();
-        let val = repr.parse().unwrap();
-        if let MorphologicalMarker::Ordinal(marker) = b.marker {
-            (format!("{}{}", b.to_string(), marker), val)
-        } else {
-            (repr, val)
-        }
-    }
-
-    fn format_decimal_and_value(
-        &self,
-        int: &DigitString,
-        dec: &DigitString,
-        sep: char,
-    ) -> (String, f64) {
-        let sint = int.to_string();
-        let sdec = dec.to_string();
-        let val = format!("{sint}.{sdec}").parse().unwrap();
-        (format!("{sint}{sep}{sdec}"), val)
-    }
-
     fn get_morph_marker(&self, word: &str) -> MorphologicalMarker {
         if word.ends_with("ème") {
             MorphologicalMarker::Ordinal("ème")
@@ -325,7 +306,7 @@ mod tests {
         ($text:expr, $res:expr) => {
             let f = French {};
             let res = text2digits($text, &f);
-            dbg!(&res);
+            crate::tests::dbg!(&res);
             assert!(res.is_ok());
             assert_eq!(res.unwrap(), $res)
         };

--- a/src/lang/it/mod.rs
+++ b/src/lang/it/mod.rs
@@ -269,26 +269,6 @@ impl LangInterpreter for Italian {
     fn check_decimal_separator(&self, word: &str) -> Option<char> {
         if word == "virgola" { Some(',') } else { None }
     }
-    fn format_and_value(&self, b: &DigitString) -> (String, f64) {
-        let repr = b.to_string();
-        let val = repr.parse().unwrap();
-        if let MorphologicalMarker::Ordinal(marker) = b.marker {
-            (format!("{}{}", b.to_string(), marker), val)
-        } else {
-            (repr, val)
-        }
-    }
-    fn format_decimal_and_value(
-        &self,
-        int: &DigitString,
-        dec: &DigitString,
-        sep: char,
-    ) -> (String, f64) {
-        let sint = int.to_string();
-        let sdec = dec.to_string();
-        let val = format!("{sint}.{sdec}").parse().unwrap();
-        (format!("{sint}{sep}{sdec}"), val)
-    }
 
     fn is_linking(&self, word: &str) -> bool {
         INSIGNIFICANT.contains(word)
@@ -304,7 +284,7 @@ mod tests {
         ($text:expr, $res:expr) => {
             let f = Italian::default();
             let res = text2digits($text, &f);
-            dbg!(&res);
+            crate::tests::dbg!(&res);
             assert!(res.is_ok());
             assert_eq!(res.unwrap(), $res)
         };

--- a/src/lang/nl/mod.rs
+++ b/src/lang/nl/mod.rs
@@ -236,29 +236,6 @@ impl LangInterpreter for Dutch {
         if word == "komma" { Some(',') } else { None }
     }
 
-    fn format_and_value(&self, b: &DigitString) -> (String, f64) {
-        let repr = b.to_string();
-        let val: f64 = repr.parse().unwrap();
-        if let MorphologicalMarker::Ordinal(marker) = b.marker {
-            (format!("{}{}", b.to_string(), marker), val)
-        } else {
-            (repr, val)
-        }
-    }
-
-    fn format_decimal_and_value(
-        &self,
-        int: &DigitString,
-        dec: &DigitString,
-        sep: char,
-    ) -> (String, f64) {
-        let irepr = int.to_string();
-        let drepr = dec.to_string();
-        let frepr = format!("{irepr}{sep}{drepr}");
-        let val = format!("{irepr}.{drepr}").parse().unwrap();
-        (frepr, val)
-    }
-
     fn get_morph_marker(&self, word: &str) -> MorphologicalMarker {
         if word.ends_with("ste") || word.ends_with("de") {
             MorphologicalMarker::Ordinal("e")
@@ -281,7 +258,7 @@ mod tests {
         ($text:expr, $res:expr) => {
             let f = Dutch::new();
             let res = text2digits($text, &f);
-            dbg!(&res);
+            crate::tests::dbg!(&res);
             assert!(res.is_ok());
             assert_eq!(res.unwrap(), $res)
         };
@@ -335,8 +312,6 @@ mod tests {
             "347625728221"
         );
     }
-
-    ///
 
     #[test]
     fn test_apply() {

--- a/src/lang/pt/mod.rs
+++ b/src/lang/pt/mod.rs
@@ -174,28 +174,6 @@ impl LangInterpreter for Portuguese {
         if word == "vírgula" { Some(',') } else { None }
     }
 
-    fn format_and_value(&self, b: &DigitString) -> (String, f64) {
-        let repr = b.to_string();
-        let val = repr.parse().unwrap();
-        if let MorphologicalMarker::Ordinal(marker) = b.marker {
-            (format!("{}{}", b.to_string(), marker), val)
-        } else {
-            (repr, val)
-        }
-    }
-
-    fn format_decimal_and_value(
-        &self,
-        int: &DigitString,
-        dec: &DigitString,
-        sep: char,
-    ) -> (String, f64) {
-        let sint = int.to_string();
-        let sdec = dec.to_string();
-        let val = format!("{sint}.{sdec}").parse().unwrap();
-        (format!("{sint}{sep}{sdec}"), val)
-    }
-
     fn is_linking(&self, word: &str) -> bool {
         INSIGNIFICANT.contains(word)
     }
@@ -210,7 +188,7 @@ mod tests {
         ($text:expr, $res:expr) => {
             let f = Portuguese {};
             let res = text2digits($text, &f);
-            dbg!(&res);
+            crate::tests::dbg!(&res);
             assert!(res.is_ok());
             assert_eq!(res.unwrap(), $res)
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@ pub(crate) mod tests {
     }
     #[allow(clippy::single_component_path_imports)]
     pub(crate) use dbg;
-    
+
     #[test]
     #[cfg(feature = "fr")]
     fn test_access_fr() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 /*!
 This crate provides a library for recognizing, parsing and transcribing into digits (base 10) numbers expressed in natural language.
 
@@ -203,9 +205,9 @@ assert_eq!(found.text, "24");
 assert_eq!(found.value, 24.0);
 assert!(!found.is_ordinal);
 ```
-
-
 */
+
+extern crate alloc;
 
 pub mod digit_string;
 pub mod error;
@@ -219,25 +221,23 @@ pub use word_to_digit::{
     replace_numbers_in_text, text2digits,
 };
 
-/// Get an interpreter for the language represented by the `language_code` ISO code.
-pub fn get_interpreter_for(language_code: &str) -> Option<Language> {
-    match language_code {
-        "de" => Some(Language::german()),
-        "en" => Some(Language::english()),
-        "es" => Some(Language::spanish()),
-        "fr" => Some(Language::french()),
-        "it" => Some(Language::italian()),
-        "nl" => Some(Language::dutch()),
-        "pt" => Some(Language::portuguese()),
-        _ => None,
-    }
-}
+pub use lang::get_interpreter_for;
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::{Language, replace_numbers_in_text};
 
+    #[cfg(not(feature = "std"))]
+    macro_rules! dbg {
+        ($($t: tt)*) => {
+            // noop - no stderr in no_std environment; don't run tests with no_std
+        };
+    }
+    #[allow(clippy::single_component_path_imports)]
+    pub(crate) use dbg;
+    
     #[test]
+    #[cfg(feature = "fr")]
     fn test_access_fr() {
         let french = Language::french();
         assert_eq!(
@@ -251,6 +251,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "fr")]
     fn test_zeros_fr() {
         let french = Language::french();
         assert_eq!(
@@ -260,6 +261,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "en")]
     fn test_access_en() {
         let english = Language::english();
         assert_eq!(

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,6 +1,6 @@
 //! Some tokenizers
 
-use alloc::{string::String, borrow::ToOwned};
+use alloc::{borrow::ToOwned, string::String};
 
 use daachorse::{
     CharwiseDoubleArrayAhoCorasick, CharwiseDoubleArrayAhoCorasickBuilder, MatchKind,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,4 +1,7 @@
 //! Some tokenizers
+
+use alloc::{string::String, borrow::ToOwned};
+
 use daachorse::{
     CharwiseDoubleArrayAhoCorasick, CharwiseDoubleArrayAhoCorasickBuilder, MatchKind,
     charwise::iter::LestmostFindIterator, errors::Result,
@@ -27,7 +30,7 @@ impl PartialEq for BasicToken {
     }
 }
 
-impl std::borrow::Borrow<str> for BasicToken {
+impl core::borrow::Borrow<str> for BasicToken {
     fn borrow(&self) -> &str {
         self.text.as_str()
     }
@@ -37,7 +40,7 @@ impl std::borrow::Borrow<str> for BasicToken {
 #[derive(Debug)]
 pub struct Tokenize<'a> {
     source: &'a str,
-    chars: std::iter::Peekable<std::str::CharIndices<'a>>,
+    chars: core::iter::Peekable<core::str::CharIndices<'a>>,
 }
 
 pub fn tokenize(source: &str) -> Tokenize<'_> {
@@ -178,13 +181,15 @@ impl WordSplitter {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use super::*;
 
     #[test]
     fn test_tokenizer() {
         let src = "Here, some phrase: hello!";
         let tokens: Vec<BasicToken> = Tokenize::new(src).collect();
-        dbg!(&tokens);
+        crate::tests::dbg!(&tokens);
         assert_eq!(tokens.len(), 8);
         assert_eq!(tokens[0].text, "Here");
         assert_eq!(tokens[1].text, ", ");
@@ -198,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_word_splitter() {
-        let german_splitter = WordSplitter::new(&[
+        let german_splitter = WordSplitter::new([
             "billion",
             "milliarde",
             "millionen",
@@ -212,7 +217,7 @@ mod tests {
         let tokens: Vec<&str> = german_splitter
             .split("tausendfünfhundertzweiunddreißig")
             .collect();
-        dbg!(&tokens);
+        crate::tests::dbg!(&tokens);
         assert_eq!(
             tokens,
             ["tausend", "fünf", "hundert", "zwei", "und", "dreißig"]

--- a/src/word_to_digit.rs
+++ b/src/word_to_digit.rs
@@ -4,8 +4,11 @@ Top level API.
 For an overview with examples and use cases, see the [crate level documentation](super).
 
 */
-use std::collections::VecDeque;
-use std::iter::Enumerate;
+
+use alloc::{string::String, vec::Vec};
+
+use alloc::collections::VecDeque;
+use core::iter::Enumerate;
 
 use crate::digit_string::DigitString;
 use crate::error::Error;
@@ -538,7 +541,7 @@ mod tests {
         }
 
         fn text_lowercase(&self) -> &str {
-            &self.lowercase.as_str()
+            self.lowercase.as_str()
         }
 
         fn nt_separated(&self, _previous: &Self) -> bool {
@@ -572,7 +575,7 @@ mod tests {
     fn test_find_isolated_single() {
         let fr = Language::french();
         let ocs = find_numbers(tokenize("c'est un logement neuf"), &fr, 10.0);
-        dbg!(&ocs);
+        crate::tests::dbg!(&ocs);
         assert!(ocs.is_empty());
     }
 
@@ -580,7 +583,7 @@ mod tests {
     fn test_find_all_isolated_single() {
         let fr = Language::french();
         let ocs = find_numbers(tokenize("c'est zéro"), &fr, 0.0);
-        dbg!(&ocs);
+        crate::tests::dbg!(&ocs);
         assert_eq!(ocs.len(), 1);
         assert_eq!(ocs[0].text, "0");
         assert_eq!(ocs[0].value, 0.0);
@@ -590,7 +593,7 @@ mod tests {
     fn test_find_isolated_long() {
         let fr = Language::french();
         let ocs = find_numbers(tokenize("trente-sept rue du docteur leroy"), &fr, 10.0);
-        dbg!(&ocs);
+        crate::tests::dbg!(&ocs);
         assert_eq!(ocs.len(), 1);
         assert_eq!(ocs[0].text, "37");
         assert_eq!(ocs[0].value, 37.0);
@@ -600,7 +603,7 @@ mod tests {
     fn test_find_isolated_with_leading_zero() {
         let fr = Language::french();
         let ocs = find_numbers(tokenize("quatre-vingt-douze slash zéro deux"), &fr, 10.0);
-        dbg!(&ocs);
+        crate::tests::dbg!(&ocs);
         assert_eq!(ocs.len(), 2);
         assert_eq!(ocs[1].text, "02");
     }


### PR DESCRIPTION
- Added `no_std` support with optional `std` feature
    - Migrated from `std` to `core` and `alloc` for `no_std` compatibility
    - Replaced `dbg!` macro calls with feature-gated versions for `no_std` compatibility
- Feature-gated language modules for selective compilation
- Default implementations for `format_and_value()` and `format_decimal_and_value()` in `LangInterpreter` trait
    - Removed duplicate `format_and_value()` and `format_decimal_and_value()` implementations from language modules
- Optimized parsing a bit
    - Previous code converted `DigitString` to `String` by prepending zeroes, then parsed the longer `String`
    - New code parses `DigitString` directly. It's infallible because only numbers are inserted by the library.
        - `DigitString` should be `pub(crate)` and not exposed by the library for this to be 100% true.
- Applied fixes for clippy warnings
- Some other very minor tweaks