### PR TITLE
Release 2.6.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/rust:1.78
+      - image: cimg/rust
     steps:
       - checkout
       - run:
@@ -33,7 +33,7 @@ jobs:
           command: cargo publish --dry-run
   deploy:
     docker:
-      - image: cimg/rust:1.78
+      - image: cimg/rust
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/rust
+      - image: cimg/rust:1.93
     steps:
       - checkout
       - run:
@@ -33,7 +33,7 @@ jobs:
           command: cargo publish --dry-run
   deploy:
     docker:
-      - image: cimg/rust
+      - image: cimg/rust:1.93
     steps:
       - checkout
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "text2num"
-version = "2.6.2"
+version = "2.6.3"
 authors = ["Allo-Media <contact@allo-media.fr>"]
-edition = "2021"
+edition = "2024"
 license = "MIT"
 description = "Parse and convert numbers written in English, Dutch, Spanish, Portuguese, German, Italian or French into their digit representation."
 keywords = ["NLP", "words-to-numbers"]

--- a/src/lang/de/mod.rs
+++ b/src/lang/de/mod.rs
@@ -213,10 +213,10 @@ impl LangInterpreter for German {
     }
 
     fn check_decimal_separator(&self, word: &str) -> Option<char> {
-        if word == "komma" {
-            Some(',')
-        } else {
-            None
+        match word {
+            "komma" => Some(','),
+            "punkt" => Some('.'),
+            _ => None,
         }
     }
 
@@ -370,8 +370,10 @@ mod tests {
         assert_replace_numbers!("eins zwei drei vier fünf und zwanzig.", "1 2 3 4 25.");
         assert_replace_numbers!("eins zwei drei vier fünfundzwanzig.", "1 2 3 4 25.");
         assert_replace_numbers!("eins zwei drei vier fünf zwanzig.", "1 2 3 4 5 20.");
-        assert_replace_numbers!("achtundachtzig sieben hundert, acht und achtzig siebenhundert, achtundachtzig sieben hundert, acht und achtzig sieben hundert",
-            "88 700, 88 700, 88 700, 88 700");
+        assert_replace_numbers!(
+            "achtundachtzig sieben hundert, acht und achtzig siebenhundert, achtundachtzig sieben hundert, acht und achtzig sieben hundert",
+            "88 700, 88 700, 88 700, 88 700"
+        );
         assert_replace_numbers!(
             "Zahlen wie vierzig fünfhundert Tausend zweiundzwanzig hundert sind gut.",
             "Zahlen wie 40 500022 100 sind gut."
@@ -469,6 +471,7 @@ mod tests {
             "Pi ist drei Komma eins vier und so weiter",
             "Pi ist 3,14 und so weiter"
         );
+        assert_replace_numbers!("drei Punkt eins vier", "3.14");
         assert_replace_numbers!("komma eins vier", "komma 1 4");
         assert_replace_all_numbers!("drei komma", "3 komma");
         assert_replace_numbers!("drei komma", "drei komma");

--- a/src/lang/de/vocabulary.rs
+++ b/src/lang/de/vocabulary.rs
@@ -1,4 +1,4 @@
-use phf::{phf_set, Set};
+use phf::{Set, phf_set};
 
 pub static INSIGNIFICANT: Set<&'static str> = phf_set! {
     "aber", "ah", "äh", "ähm", "also", "gut", "auch", "denn", "doch", "dort", "eben", "eh", "halt", "ja", "mal", "sehen", "naja", "nun", "ok", "schon", "so", "genau", "und", "noch"

--- a/src/lang/en/mod.rs
+++ b/src/lang/en/mod.rs
@@ -121,11 +121,7 @@ impl LangInterpreter for English {
     }
 
     fn check_decimal_separator(&self, word: &str) -> Option<char> {
-        if word == "point" {
-            Some('.')
-        } else {
-            None
-        }
+        if word == "point" { Some('.') } else { None }
     }
 
     fn format_and_value(&self, b: &DigitString) -> (String, f64) {

--- a/src/lang/en/vocabulary.rs
+++ b/src/lang/en/vocabulary.rs
@@ -1,4 +1,4 @@
-use phf::{phf_set, Set};
+use phf::{Set, phf_set};
 
 pub static INSIGNIFICANT: Set<&'static str> = phf_set! {
     "and", "ha", "ah", "hu", "hum", "minus", "more", "ok", "plus", "so", "that's", "then", "uh", "well", "yeah", "yes", "is"

--- a/src/lang/es/vocabulary.rs
+++ b/src/lang/es/vocabulary.rs
@@ -1,4 +1,4 @@
-use phf::{phf_set, Set};
+use phf::{Set, phf_set};
 
 pub static INSIGNIFICANT: Set<&'static str> = phf_set! {
     "pues", "y", "digo", "o", "sea", "entonces", "así", "que", "bueno", "es", "eso", "en", "fin", "luego", "mas", "menos", "pero", "vale", "eh", "ah", "oye", "ya", "hum", "ok", "sí", "no", "con", "son"

--- a/src/lang/fr/mod.rs
+++ b/src/lang/fr/mod.rs
@@ -226,11 +226,7 @@ impl LangInterpreter for French {
     }
 
     fn check_decimal_separator(&self, word: &str) -> Option<char> {
-        if word == "virgule" {
-            Some(',')
-        } else {
-            None
-        }
+        if word == "virgule" { Some(',') } else { None }
     }
 
     fn format_and_value(&self, b: &DigitString) -> (String, f64) {

--- a/src/lang/fr/vocabulary.rs
+++ b/src/lang/fr/vocabulary.rs
@@ -1,4 +1,4 @@
-use phf::{phf_set, Set};
+use phf::{Set, phf_set};
 
 pub static INSIGNIFICANT: Set<&'static str> = phf_set! {
     "alors", "bien", "c'est", "encore", "ensuite", "et", "euh", "heu", "ha", "ah", "hu", "hum", "moins", "ok", "oui", "plus", "puis", "voilà"

--- a/src/lang/it/mod.rs
+++ b/src/lang/it/mod.rs
@@ -267,11 +267,7 @@ impl LangInterpreter for Italian {
         }
     }
     fn check_decimal_separator(&self, word: &str) -> Option<char> {
-        if word == "virgola" {
-            Some(',')
-        } else {
-            None
-        }
+        if word == "virgola" { Some(',') } else { None }
     }
     fn format_and_value(&self, b: &DigitString) -> (String, f64) {
         let repr = b.to_string();

--- a/src/lang/it/vocabulary.rs
+++ b/src/lang/it/vocabulary.rs
@@ -1,4 +1,4 @@
-use phf::{phf_set, Set};
+use phf::{Set, phf_set};
 
 pub static INSIGNIFICANT: Set<&'static str> = phf_set! {
     "e", "ehm", "più", "poi", "ancora", "meno", "è", "ben"

--- a/src/lang/nl/mod.rs
+++ b/src/lang/nl/mod.rs
@@ -179,7 +179,6 @@ impl LangInterpreter for Dutch {
             }
             "honderd" | "honderdste" => {
                 let peek = b.peek(2);
-                dbg!(&peek);
                 if peek.len() == 1 && peek == b"1" {
                     Err(Error::Overlap)
                 } else {

--- a/src/lang/nl/mod.rs
+++ b/src/lang/nl/mod.rs
@@ -234,11 +234,7 @@ impl LangInterpreter for Dutch {
     }
 
     fn check_decimal_separator(&self, word: &str) -> Option<char> {
-        if word == "komma" {
-            Some(',')
-        } else {
-            None
-        }
+        if word == "komma" { Some(',') } else { None }
     }
 
     fn format_and_value(&self, b: &DigitString) -> (String, f64) {
@@ -335,7 +331,10 @@ mod tests {
             "Tweehonderdeenenzeventigduizend achthonderdvijftig",
             "271850"
         );
-        assert_text2digits!("Driehonderdzevenenveertig miljard zeshonderdvijfentwintig miljoen zevenhonderdachtentwintigduizend tweehonderdeenentwintig", "347625728221");
+        assert_text2digits!(
+            "Driehonderdzevenenveertig miljard zeshonderdvijfentwintig miljoen zevenhonderdachtentwintigduizend tweehonderdeenentwintig",
+            "347625728221"
+        );
     }
 
     ///
@@ -476,9 +475,9 @@ mod tests {
     #[test]
     fn test_replace_numbers_decimals() {
         assert_replace_numbers!(
-                    "Twaalf komma negenennegentig, honderdtwintig komma nul vijf, één komma tweehonderdzesendertig, één komma twee drie zes.",
-                    "12,99, 120,05, 1,236, 1,2 3 6."
-                );
+            "Twaalf komma negenennegentig, honderdtwintig komma nul vijf, één komma tweehonderdzesendertig, één komma twee drie zes.",
+            "12,99, 120,05, 1,236, 1,2 3 6."
+        );
         // assert_replace_numbers!(
         //     "Twaalf komma negen negen, honderdtwintig komma nul vijf, één komma twee drie zes, één komma tweehonderdzesendertig.",
         //     "12,99, 120,05, 1,236, 1 komma 236."

--- a/src/lang/nl/vocabulary.rs
+++ b/src/lang/nl/vocabulary.rs
@@ -1,4 +1,4 @@
-use phf::{phf_set, Set};
+use phf::{Set, phf_set};
 
 pub static INSIGNIFICANT: Set<&'static str> = phf_set! {
     "ja", "dus", "plus", "uh", "dan", "min", "dat", "is"

--- a/src/lang/pt/mod.rs
+++ b/src/lang/pt/mod.rs
@@ -171,11 +171,7 @@ impl LangInterpreter for Portuguese {
         }
     }
     fn check_decimal_separator(&self, word: &str) -> Option<char> {
-        if word == "vírgula" {
-            Some(',')
-        } else {
-            None
-        }
+        if word == "vírgula" { Some(',') } else { None }
     }
 
     fn format_and_value(&self, b: &DigitString) -> (String, f64) {
@@ -265,7 +261,10 @@ mod tests {
             "novecentos e noventa e nove mil novecentos e noventa e nove",
             "999999"
         );
-        assert_text2digits!("cinquenta e três mil e vinte milhões duzentos e quarenta e três mil setecentos e vinte e quatro", "53020243724");
+        assert_text2digits!(
+            "cinquenta e três mil e vinte milhões duzentos e quarenta e três mil setecentos e vinte e quatro",
+            "53020243724"
+        );
         assert_text2digits!(
             "cinquenta e um milhões quinhentos e setenta e oito mil trezentos e dois",
             "51578302"
@@ -437,6 +436,9 @@ mod tests {
             "dois milhões oitocentos e quarenta e quatro mil trezentos e trinta e três",
             "2844333"
         );
-        assert_text2digits!("cinquenta e três bilhões e vinte milhões duzentos e quarenta e três mil setecentos e vinte e quatro", "53020243724");
+        assert_text2digits!(
+            "cinquenta e três bilhões e vinte milhões duzentos e quarenta e três mil setecentos e vinte e quatro",
+            "53020243724"
+        );
     }
 }

--- a/src/lang/pt/vocabulary.rs
+++ b/src/lang/pt/vocabulary.rs
@@ -1,4 +1,4 @@
-use phf::{phf_set, Set};
+use phf::{Set, phf_set};
 
 pub static INSIGNIFICANT: Set<&'static str> = phf_set! {
     "eh", "então", "bem", "isso", "outra vez", "e", "uh", "ha", "ah", "hu", "um", "menos", "ok", "sim", "mais", "aí está",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,8 +215,8 @@ pub mod word_to_digit;
 
 pub use lang::{BasicAnnotate, LangInterpreter, Language};
 pub use word_to_digit::{
-    find_numbers, find_numbers_iter, replace_numbers_in_stream, replace_numbers_in_text,
-    text2digits, Occurence, Replace, Token,
+    Occurence, Replace, Token, find_numbers, find_numbers_iter, replace_numbers_in_stream,
+    replace_numbers_in_text, text2digits,
 };
 
 /// Get an interpreter for the language represented by the `language_code` ISO code.
@@ -235,7 +235,7 @@ pub fn get_interpreter_for(language_code: &str) -> Option<Language> {
 
 #[cfg(test)]
 mod tests {
-    use super::{replace_numbers_in_text, Language};
+    use super::{Language, replace_numbers_in_text};
 
     #[test]
     fn test_access_fr() {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,7 +1,7 @@
 //! Some tokenizers
 use daachorse::{
-    charwise::iter::LestmostFindIterator, errors::Result, CharwiseDoubleArrayAhoCorasick,
-    CharwiseDoubleArrayAhoCorasickBuilder, MatchKind,
+    CharwiseDoubleArrayAhoCorasick, CharwiseDoubleArrayAhoCorasickBuilder, MatchKind,
+    charwise::iter::LestmostFindIterator, errors::Result,
 };
 
 #[derive(Debug)]

--- a/src/word_to_digit.rs
+++ b/src/word_to_digit.rs
@@ -10,7 +10,7 @@ use std::iter::Enumerate;
 use crate::digit_string::DigitString;
 use crate::error::Error;
 use crate::lang::{BasicAnnotate, LangInterpreter};
-use crate::tokenizer::{tokenize, BasicToken};
+use crate::tokenizer::{BasicToken, tokenize};
 
 struct WordToDigitParser<'a, T: LangInterpreter> {
     int_part: DigitString,
@@ -619,7 +619,10 @@ mod tests {
                 &fr,
                 10.0,
             );
-            assert_eq!(wyget, "25 vaches, 12 poulets et 125 kg de pommes de terre.\n            1266 clous. 09 60 06 12 21.\n            les uns et les autres ; une suite de chiffres : 1, 2, 3 !\n            53000243724.\n            ");
+            assert_eq!(
+                wyget,
+                "25 vaches, 12 poulets et 125 kg de pommes de terre.\n            1266 clous. 09 60 06 12 21.\n            les uns et les autres ; une suite de chiffres : 1, 2, 3 !\n            53000243724.\n            "
+            );
         }
     }
 }


### PR DESCRIPTION
* [German now accept both Komma and Punkt as decimal separtor.](https://github.com/allo-media/text2num-rs/commit/8df243537e9d72ab0ed4164770e31d2a8b5715c7)
* Edition 2024
* Removed debugging leftover in NL module.